### PR TITLE
refactor: use io.ReadAll instead of ioutil.readAll

### DIFF
--- a/examples/dogs-api/app.go
+++ b/examples/dogs-api/app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -33,7 +33,7 @@ func (a *App) FetchAnyBreed() map[string]string {
 		log.Fatal(err)
 	}
 
-	responseData, err := ioutil.ReadAll(response.Body)
+	responseData, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func (a *App) SelectBreed() []string {
 		log.Fatal(err)
 	}
 
-	responseData, err := ioutil.ReadAll(response.Body)
+	responseData, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func (a *App) FetchByBreed(breed string) []string {
 		log.Fatal(err)
 	}
 
-	responseData, err := ioutil.ReadAll(response.Body)
+	responseData, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The use of ioutil.ReadAll is deprecated.